### PR TITLE
Set default data for httpRequest.write

### DIFF
--- a/lib/handy-http.js
+++ b/lib/handy-http.js
@@ -99,7 +99,10 @@ HTTPClient.prototype.open = function (connection, callback) {
             headers['content-length'] = Buffer.byteLength(data);
             break;
         default:
-            // ?
+            // HTTPRequest.write method require data parametr must be String or Buffer instance
+            // if we didnt set content-type or data param we get data=undefined and
+            // HTTPRequest TypeError: first argument must be a string or Buffer http.js:851 
+            data = '';
     }
 
     if(proxy) {


### PR DESCRIPTION
HTTPRequest.write method require data parametr must be String or Buffer instance if we didnt set content-type or data param we get data=undefined and HTTPRequest TypeError: first argument must be a string or Buffer http.js:851
